### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,24 @@ Clone the repository into `~/.local/share/icons/Neuwaita`:
 git clone --depth 1 git@github.com:RusticBard/Neuwaita.git ~/.local/share/icons/Neuwaita
 ```
 
+or
+
+```
+sudo git clone --depth 1 https://github.com/RusticBard/Neuwaita.git ~/.local/share/icons/Neuwaita
+```
+
 ### System-wide installation
 
 Clone the repository into `/usr/share/icons`
 
 ```
 sudo git clone --depth 1 git@github.com:RusticBard/Neuwaita.git /usr/share/icons/Neuwaita
+```
+
+or
+
+```
+sudo git clone --depth 1 https://github.com/RusticBard/Neuwaita.git /usr/share/icons/Neuwaita
 ```
 
 ## Updating


### PR DESCRIPTION
I noticed the install command in the **README** uses an **SSH URL**, which requires SSH key setup and may cause permission errors for users just trying to clone the public repository. 

I’ve updated it to use the **HTTPS** clone URL for easier access.

Thanks for your awesome icon theme!